### PR TITLE
[Fix / Feat] 添加心跳

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,19 @@ $ poetry install
 启动服务端
 
 ```bash
-$ poetry run tsuraika server -p 7000 -d
+$ poetry run tsuraika server -p 7000
 ```
 
 启动客户端
 
 ```bash
-$ poetry run tsuraika client -c /path/to/config.json -d
+$ poetry run tsuraika client -c /path/to/config.json
 ```
 
 ### 命令行参数 / CLI Arguments
+
+> [!WARNING]
+> 正常情况下请勿启用 `--verbose`, 可能造成严重性能损耗
 
 #### 服务端选项
 
@@ -74,10 +77,12 @@ $ poetry run tsuraika client -c /path/to/config.json -d
 $ poetry run tsuraika server [options]
 ```
 
-| 选项            | 说明                      | 默认值 |
-| --------------- | ------------------------- | ------ |
-| `--port`, `-p`  | 服务端端口                | `7000` |
-| `--debug`, `-d` | 调试模式 (详细控制台输出) | 禁用   |
+| 选项                    | 说明                      | 默认值 |
+| ----------------------- | ------------------------- | ------ |
+| `--port`, `-p`          | 服务端端口                | `7000` |
+| `--debug`, `-d`         | 调试模式 (更多控制台输出) | 禁用   |
+| `--verbose`, `-v`       | 详细模式 (全部控制台输出) | 禁用   |
+| `--basic-colors`, `-bc` | 使用基础 ANSI 颜色        | 禁用   |
 
 #### 客户端选项
 
@@ -85,16 +90,18 @@ $ poetry run tsuraika server [options]
 $ poetry run tsuraika client [options]
 ```
 
-| 选项                   | 说明                        | 默认值      |
-| ---------------------- | --------------------------- | ----------- |
-| `--config`, `-c`       | 配置文件路径                | 空          |
-| `--server`, `-s`       | 服务端地址                  | `127.0.0.1` |
-| `--server-port`, `-sp` | 服务端端口                  | `7000`      |
-| `--local`, `-l`        | 本地服务地址                | `127.0.0.1` |
-| `--local-port`, `-lp`  | 本地服务端口                | `8080`      |
-| `--remote-port`, `-rp` | 服务端暴露端口 (`0 = 随机`) | `0`         |
-| `--name`, `-n`         | 客户端名称                  | 空          |
-| `--debug`, `-d`        | 调试模式 (详细控制台输出)   | 禁用        |
+| 选项                    | 说明                        | 默认值      |
+| ----------------------- | --------------------------- | ----------- |
+| `--config`, `-c`        | 配置文件路径                | 空          |
+| `--server`, `-s`        | 服务端地址                  | `127.0.0.1` |
+| `--server-port`, `-sp`  | 服务端端口                  | `7000`      |
+| `--local`, `-l`         | 本地服务地址                | `127.0.0.1` |
+| `--local-port`, `-lp`   | 本地服务端口                | `8080`      |
+| `--remote-port`, `-rp`  | 服务端暴露端口 (`0 = 随机`) | `0`         |
+| `--name`, `-n`          | 客户端名称                  | 空          |
+| `--debug`, `-d`         | 调试模式 (更多控制台输出)   | 禁用        |
+| `--verbose`, `-v`       | 详细模式 (全部控制台输出)   | 禁用        |
+| `--basic-colors`, `-bc` | 使用基础 ANSI 颜色          | 禁用        |
 
 ### 更新日志 / Update Logs
 

--- a/tsuraika/cli.py
+++ b/tsuraika/cli.py
@@ -8,7 +8,7 @@ from rich import print
 from rich.console import Console
 from importlib.metadata import version
 
-from .common import logger, ClientConfig
+from .common import VERBOSE, logger, ClientConfig, setup_logging
 from .server import ProxyServer
 from .client import ProxyClient, load_config
 
@@ -51,14 +51,34 @@ def common(
 def server(
     port: int = typer.Option(7000, "--port", "-p", help="Server port (default: 7000)"),
     debug: bool = typer.Option(False, "--debug", "-d", help="Enable debug logging"),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Enable verbose logging"
+    ),
+    heartbeat_interval: int = typer.Option(
+        60, "--heartbeat", "-hb", help="Server heartbeat interval in seconds (min 5s)"
+    ),
+    basic_colors: bool = typer.Option(
+        False,
+        "--basic-colors",
+        "-bc",
+        help="Use basic ANSI colors instead of hex colors",
+    ),
 ):
     """Start the server"""
-    if debug:
+    if heartbeat_interval < 5:
+        console.print("[red]Error: Heartbeat interval must be at least 5 seconds[/red]")
+        sys.exit(1)
+
+    global logger
+    logger = setup_logging(use_basic_colors=basic_colors)
+    if verbose:
+        logger.setLevel(VERBOSE)
+    elif debug:
         logger.setLevel(logging.DEBUG)
 
     try:
         with console.status("[bold green]Starting server..."):
-            server_instance = ProxyServer(port)
+            server_instance = ProxyServer(port, heartbeat_interval=heartbeat_interval)
             console.print(f"[green]Server started on port {port}[/green]")
 
         asyncio.run(server_instance.start())
@@ -89,9 +109,22 @@ def client(
     ),
     proxy_name: str = typer.Option(None, "--name", "-n", help="Proxy name"),
     debug: bool = typer.Option(False, "--debug", "-d", help="Enable debug logging"),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Enable verbose logging"
+    ),
+    basic_colors: bool = typer.Option(
+        False,
+        "--basic-colors",
+        "-bc",
+        help="Use basic ANSI colors instead of hex colors",
+    ),
 ):
     """Start the client"""
-    if debug:
+    global logger
+    logger = setup_logging(use_basic_colors=basic_colors)
+    if verbose:
+        logger.setLevel(VERBOSE)
+    elif debug:
         logger.setLevel(logging.DEBUG)
 
     try:

--- a/tsuraika/client.py
+++ b/tsuraika/client.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 import msgpack
 import json
 import os
@@ -10,6 +11,10 @@ class ProxyClient:
         self.config = config
         self.local_connections = {}
         self.server_writer = None
+        self.heartbeat_interval = 60
+        self.last_server_heartbeat = 0
+        self.connection_lost = False
+        self.is_closing = False
 
     def decode_if_bytes(self, value):
         if isinstance(value, bytes):
@@ -40,7 +45,7 @@ class ProxyClient:
                             "connection_id": connection_id,
                         },
                     }
-                    logger.debug(f"Forwarding local data to server: {message}")
+                    logger.verbose(f"Forwarding local data to server: {message}")
                     packed_data = msgpack.packb(message)
                     self.server_writer.write(packed_data)
                     await self.server_writer.drain()
@@ -62,7 +67,7 @@ class ProxyClient:
                 self.config.local_addr, self.config.local_port
             )
             self.local_connections[connection_id] = (reader, writer)
-            logger.info(
+            logger.debug(
                 f"Created new local connection {connection_id} to {self.config.local_addr}:{self.config.local_port}"
             )
 
@@ -73,99 +78,156 @@ class ProxyClient:
             logger.error(f"Failed to create local connection: {e}")
             raise
 
-    async def handle_server_data(self, reader: asyncio.StreamReader):
-        try:
-            while True:
-                packed_data = await reader.read(8192)
-                if not packed_data:
-                    break
+    async def handle_server_heartbeat(self):
+        while True:
+            current_time = asyncio.get_event_loop().time()
+            if current_time - self.last_server_heartbeat > self.heartbeat_interval:
+                await self.send_heartbeat()
+            await asyncio.sleep(1)
 
-                try:
-                    message = msgpack.unpackb(packed_data)
-                    logger.debug(f"Received message from server: {message}")
-
-                    if not validate_message(message):
-                        logger.error("Invalid message format received from server")
-                        continue
-
-                    msg_type = self.decode_if_bytes(
-                        self.get_message_field(message, "type")
-                    )
-                    data = self.get_message_field(message, "data")
-
-                    if msg_type == MessageType.INITIAL_RESPONSE.value:
-                        remote_port = self.get_data_field(data, "remote_port")
-                        proxy_name = self.decode_if_bytes(
-                            self.get_data_field(data, "proxy_name")
-                        )
-                        logger.info(
-                            f"Proxy established on remote port: {remote_port} for {proxy_name}"
-                        )
-
-                    elif msg_type == MessageType.DATA.value:
-                        proxy_name = self.decode_if_bytes(
-                            self.get_data_field(data, "proxy_name")
-                        )
-                        if proxy_name == self.config.proxy_name:
-                            binary_data = self.get_data_field(data, "data")
-                            connection_id = self.decode_if_bytes(
-                                self.get_data_field(data, "connection_id")
-                            )
-
-                            if connection_id not in self.local_connections:
-                                _, writer = await self.create_local_connection(
-                                    connection_id
-                                )
-                            else:
-                                _, writer = self.local_connections[connection_id]
-
-                            writer.write(binary_data)
-                            await writer.drain()
-                            logger.debug(
-                                f"Forwarded data to local service for connection {connection_id}"
-                            )
-
-                except msgpack.UnpackException as e:
-                    logger.error(f"Failed to unpack message: {e}")
-                except Exception as e:
-                    logger.error(f"Error processing message: {e}")
-                    logger.exception(e)
-
-        except Exception as e:
-            logger.error(f"Server connection error: {e}")
-            logger.exception(e)
-        finally:
-            for connection_id, (_, writer) in self.local_connections.items():
-                writer.close()
-                await writer.wait_closed()
-            self.local_connections.clear()
-
-    async def start(self):
-        try:
-            reader, writer = await asyncio.open_connection(
-                self.config.server_addr, self.config.server_port
-            )
-            self.server_writer = writer
-            logger.info(
-                f"Connected to server at {self.config.server_addr}:{self.config.server_port}"
-            )
-
-            initial_request = {
-                "type": MessageType.INITIAL_REQUEST.value,
+    async def send_heartbeat(self):
+        if self.server_writer:
+            message = {
+                "type": MessageType.CLIENT_HEARTBEAT.value,
                 "data": {
-                    "proxy_type": "tcp",
-                    "remote_port": self.config.remote_port,
                     "proxy_name": self.config.proxy_name,
                 },
             }
+            self.server_writer.write(msgpack.packb(message))
+            await self.server_writer.drain()
+            logger.debug("Sent heartbeat to server")
 
-            writer.write(msgpack.packb(initial_request))
-            await writer.drain()
+    async def handle_server_data(self, reader: asyncio.StreamReader):
+        unpacker = msgpack.Unpacker()
+        try:
+            while True:
+                try:
+                    packed_data = await asyncio.wait_for(
+                        reader.read(8192), timeout=self.heartbeat_interval + 5
+                    )
+                    if not packed_data:
+                        logger.warning("Server closed the connection")
+                        return
 
-            await self.handle_server_data(reader)
+                    unpacker.feed(packed_data)
+                    for message in unpacker:
+                        try:
+                            if not validate_message(message):
+                                logger.error(
+                                    "Invalid message format received from server"
+                                )
+                                continue
 
+                            msg_type = self.decode_if_bytes(
+                                self.get_message_field(message, "type")
+                            )
+
+                            if msg_type == MessageType.DATA.value:
+                                logger.verbose(f"Received data message: {message}")
+                            else:
+                                logger.debug(f"Received message: {message}")
+
+                            data = self.get_message_field(message, "data")
+
+                            if msg_type == MessageType.INITIAL_RESPONSE.value:
+                                remote_port = self.get_data_field(data, "remote_port")
+                                proxy_name = self.decode_if_bytes(
+                                    self.get_data_field(data, "proxy_name")
+                                )
+                                logger.info(
+                                    f"Proxy established on remote port: {remote_port} for {proxy_name}"
+                                )
+
+                            elif msg_type == MessageType.DATA.value:
+                                proxy_name = self.decode_if_bytes(
+                                    self.get_data_field(data, "proxy_name")
+                                )
+                                if proxy_name == self.config.proxy_name:
+                                    binary_data = self.get_data_field(data, "data")
+                                    connection_id = self.decode_if_bytes(
+                                        self.get_data_field(data, "connection_id")
+                                    )
+
+                                    if connection_id not in self.local_connections:
+                                        _, writer = await self.create_local_connection(
+                                            connection_id
+                                        )
+                                    else:
+                                        _, writer = self.local_connections[
+                                            connection_id
+                                        ]
+
+                                    writer.write(binary_data)
+                                    await writer.drain()
+                                    logger.debug(
+                                        f"Forwarded data to local service for connection {connection_id}"
+                                    )
+
+                            elif msg_type == MessageType.SERVER_HEARTBEAT.value:
+                                self.heartbeat_interval = self.get_data_field(
+                                    data, "heartbeat_interval"
+                                )
+                                self.last_server_heartbeat = (
+                                    asyncio.get_event_loop().time()
+                                )
+                                logger.debug(
+                                    f"Received server heartbeat, interval: {self.heartbeat_interval}"
+                                )
+                                continue
+
+                            elif msg_type == MessageType.CLEANUP_RESPONSE.value:
+                                proxy_name = self.decode_if_bytes(
+                                    self.get_data_field(data, "proxy_name")
+                                )
+                                status = self.decode_if_bytes(
+                                    self.get_data_field(data, "status")
+                                )
+                                if proxy_name == self.config.proxy_name:
+                                    if status == "success":
+                                        logger.info(
+                                            f"Cleanup request success for {proxy_name}"
+                                        )
+                                    else:
+                                        logger.warning(
+                                            f"Cleanup request failed for {proxy_name}"
+                                        )
+                                else:
+                                    logger.warning(
+                                        f"Received cleanup response for unknown proxy: {proxy_name}"
+                                    )
+                                continue
+
+                        except Exception as e:
+                            logger.error(f"Error processing message: {e}")
+                            logger.exception(e)
+
+                except asyncio.CancelledError:
+                    logger.info("Server data handling task cancelled")
+                    logger.info("Cleaning up and exiting client...")
+                    self.is_closing = True
+                    await self.cleanup()
+                    for task in asyncio.all_tasks():
+                        if task is not asyncio.current_task():
+                            task.cancel()
+                    await asyncio.gather(*asyncio.all_tasks(), return_exceptions=True)
+                    return
+
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "No data received from server for an extended period"
+                    )
+                    return
+
+        except (
+            ConnectionResetError,
+            ConnectionAbortedError,
+            asyncio.IncompleteReadError,
+        ) as e:
+            logger.error(f"Connection error: {e}")
+        except msgpack.exceptions.UnpackException as e:
+            logger.error(f"Unpack error: {e}")
         except Exception as e:
-            logger.error(f"Failed to connect to server: {e}")
+            logger.error(f"Unexpected error in handle_server_data: {e}")
             logger.exception(e)
         finally:
             for connection_id, (_, writer) in self.local_connections.items():
@@ -173,9 +235,115 @@ class ProxyClient:
                 await writer.wait_closed()
             self.local_connections.clear()
 
-            if self.server_writer:
-                self.server_writer.close()
-                await self.server_writer.wait_closed()
+    async def cleanup(self):
+        if self.server_writer and not self.connection_lost:
+            cleanup_request = {
+                "type": MessageType.CLEANUP_REQUEST.value,
+                "data": {
+                    "proxy_name": self.config.proxy_name,
+                },
+            }
+            self.server_writer.write(msgpack.packb(cleanup_request))
+            await self.server_writer.drain()
+
+            try:
+                cleanup_response = await asyncio.wait_for(
+                    self.reader.read(8192), timeout=5.0
+                )
+                unpacked_response = msgpack.unpackb(cleanup_response)
+                if (
+                    self.get_message_field(unpacked_response, "type")
+                    == MessageType.CLEANUP_RESPONSE.value
+                ):
+                    logger.info("Cleanup request acknowledged by server")
+                else:
+                    logger.warning("Unexpected response to cleanup request")
+            except asyncio.TimeoutError:
+                logger.warning("Timeout waiting for cleanup response from server")
+
+        for connection_id, (_, writer) in self.local_connections.items():
+            writer.close()
+            await writer.wait_closed()
+        self.local_connections.clear()
+
+        if self.server_writer and not self.connection_lost:
+            logger.info("Closing server writer")
+            self.server_writer.close()
+            logger.info("Server writer closed")
+            sys.exit(0)
+
+    async def connect_to_server(self):
+        while True:
+            try:
+                self.reader, self.server_writer = await asyncio.open_connection(
+                    self.config.server_addr, self.config.server_port
+                )
+                logger.info(
+                    f"Connected to server at {self.config.server_addr}:{self.config.server_port}"
+                )
+                return
+            except Exception as e:
+                if self.connection_lost:
+                    logger.info("Connection lost, retry in 3 seconds...")
+                    await asyncio.sleep(3)
+                else:
+                    logger.error(
+                        f"Failed to connect to server: {e}, retry in 30 seconds..."
+                    )
+                    await asyncio.sleep(30)
+
+    async def start(self):
+        while True:
+            try:
+                logger.info("Connecting to server...")
+
+                await self.connect_to_server()
+
+                initial_request = {
+                    "type": MessageType.INITIAL_REQUEST.value,
+                    "data": {
+                        "proxy_type": "tcp",
+                        "remote_port": self.config.remote_port,
+                        "proxy_name": self.config.proxy_name,
+                    },
+                }
+
+                self.server_writer.write(msgpack.packb(initial_request))
+                await self.server_writer.drain()
+
+                heartbeat_task = asyncio.create_task(self.handle_server_heartbeat())
+
+                try:
+                    await self.handle_server_data(self.reader)
+                except Exception as e:
+                    logger.error(f"Error in handle_server_data: {e}")
+                    logger.exception(e)
+                finally:
+                    heartbeat_task.cancel()
+                    try:
+                        await heartbeat_task
+                    except asyncio.CancelledError:
+                        pass
+
+                logger.info("Connection to server lost, attempting to reconnect...")
+            except Exception as e:
+                logger.error(f"Connection to server lost: {e}, retry in 3 seconds...")
+                logger.exception(e)
+            finally:
+                if not self.is_closing:
+                    logger.info("Attempting to reconnect in 3 seconds...")
+                    self.connection_lost = True
+                    try:
+                        if self.server_writer:
+                            self.server_writer.close()
+                            await self.server_writer.wait_closed()
+                        await self.cleanup()
+                        await asyncio.sleep(3)
+                    except Exception as e:
+                        logger.error(f"Error in cleanup: {e}")
+                        logger.exception(e)
+                else:
+                    logger.info("Client is closing, exiting")
 
 
 def load_config(config_path: str) -> ClientConfig:

--- a/tsuraika/common.py
+++ b/tsuraika/common.py
@@ -1,10 +1,103 @@
 import logging
 from enum import Enum
 from dataclasses import dataclass
+import colorama
 
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
+colorama.init()
+
+
+class Colors:
+    class Basic:
+        TIME = "\033[92m"
+        SOURCE = "\033[93m"
+        INFO = "\033[94m"
+        WARNING = "\033[32m"
+        ERROR = "\033[91m"
+        DEBUG = "\033[33m"
+        VERBOSE = "\033[95m"
+        RESET = "\033[0m"
+
+    class Hex:
+        TIME = "\033[38;2;144;238;144m"
+        SOURCE = "\033[38;2;180;149;212m"
+        INFO = "\033[38;2;102;204;255m"
+        WARNING = "\033[38;2;251;129;144m"
+        ERROR = "\033[38;2;229;61;48m"
+        DEBUG = "\033[38;2;137;137;255m"
+        VERBOSE = "\033[38;2;119;188;195m"
+        RESET = "\033[0m"
+
+
+class ColoredFormatter(logging.Formatter):
+    def __init__(self, use_basic_colors=False):
+        super().__init__()
+        self.colors = Colors.Basic if use_basic_colors else Colors.Hex
+        self.default_formatter = logging.Formatter(
+            f"{self.colors.TIME}%(asctime)s{self.colors.RESET} - "
+            f"{self.colors.SOURCE}%(name)s{self.colors.RESET} - "
+            "%(levelname)s - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+
+        self.formatters = {
+            logging.INFO: logging.Formatter(
+                f"{self.colors.TIME}%(asctime)s{self.colors.RESET} - "
+                f"{self.colors.SOURCE}%(name)s{self.colors.RESET} - "
+                f"{self.colors.INFO}%(levelname)s - %(message)s{self.colors.RESET}",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            ),
+            logging.WARNING: logging.Formatter(
+                f"{self.colors.TIME}%(asctime)s{self.colors.RESET} - "
+                f"{self.colors.SOURCE}%(name)s{self.colors.RESET} - "
+                f"{self.colors.WARNING}%(levelname)s - %(message)s{self.colors.RESET}",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            ),
+            logging.ERROR: logging.Formatter(
+                f"{self.colors.TIME}%(asctime)s{self.colors.RESET} - "
+                f"{self.colors.SOURCE}%(name)s{self.colors.RESET} - "
+                f"{self.colors.ERROR}%(levelname)s - %(message)s{self.colors.RESET}",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            ),
+            logging.DEBUG: logging.Formatter(
+                f"{self.colors.TIME}%(asctime)s{self.colors.RESET} - "
+                f"{self.colors.SOURCE}%(name)s{self.colors.RESET} - "
+                f"{self.colors.DEBUG}%(levelname)s - %(message)s{self.colors.RESET}",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            ),
+            VERBOSE: logging.Formatter(
+                f"{self.colors.TIME}%(asctime)s{self.colors.RESET} - "
+                f"{self.colors.SOURCE}%(name)s{self.colors.RESET} - "
+                f"{self.colors.VERBOSE}%(levelname)s - %(message)s{self.colors.RESET}",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            ),
+        }
+
+    def format(self, record):
+        formatter = self.formatters.get(record.levelno, self.default_formatter)
+        return formatter.format(record)
+
+
+VERBOSE = 5
+logging.addLevelName(VERBOSE, "VERBOSE")
+
+
+class VerboseLogger(logging.Logger):
+    def verbose(self, message, *args, **kwargs):
+        if self.isEnabledFor(VERBOSE):
+            self._log(VERBOSE, message, args, **kwargs)
+
+
+logging.setLoggerClass(VerboseLogger)
+
+
+def setup_logging(use_basic_colors=False):
+    handler = logging.StreamHandler()
+    handler.setFormatter(ColoredFormatter(use_basic_colors))
+
+    logging.basicConfig(level=logging.INFO, handlers=[handler])
+
+    return logging.getLogger("tsuraika")
+
 
 logger = logging.getLogger("tsuraika")
 
@@ -13,6 +106,10 @@ class MessageType(Enum):
     INITIAL_REQUEST = "initial_request"
     INITIAL_RESPONSE = "initial_response"
     DATA = "data"
+    CLEANUP_REQUEST = "cleanup_request"
+    CLEANUP_RESPONSE = "cleanup_response"
+    SERVER_HEARTBEAT = "server_heartbeat"
+    CLIENT_HEARTBEAT = "client_heartbeat"
 
 
 @dataclass
@@ -67,6 +164,38 @@ def validate_message(message: dict) -> bool:
                 {b"proxy_name", b"data"}
                 if isinstance(next(iter(data.keys())), bytes)
                 else {"proxy_name", "data"}
+            )
+            return all(field in data for field in required_fields)
+
+        elif msg_type == MessageType.CLEANUP_REQUEST.value:
+            required_fields = (
+                {b"proxy_name"}
+                if isinstance(next(iter(data.keys())), bytes)
+                else {"proxy_name"}
+            )
+            return all(field in data for field in required_fields)
+
+        elif msg_type == MessageType.CLEANUP_RESPONSE.value:
+            required_fields = (
+                {b"proxy_name", b"status"}
+                if isinstance(next(iter(data.keys())), bytes)
+                else {"proxy_name", "status"}
+            )
+            return all(field in data for field in required_fields)
+
+        elif msg_type == MessageType.CLIENT_HEARTBEAT.value:
+            required_fields = (
+                {b"proxy_name"}
+                if isinstance(next(iter(data.keys())), bytes)
+                else {"proxy_name"}
+            )
+            return all(field in data for field in required_fields)
+
+        elif msg_type == MessageType.SERVER_HEARTBEAT.value:
+            required_fields = (
+                {b"heartbeat_interval"}
+                if isinstance(next(iter(data.keys())), bytes)
+                else {"heartbeat_interval"}
             )
             return all(field in data for field in required_fields)
 

--- a/tsuraika/server.py
+++ b/tsuraika/server.py
@@ -5,11 +5,14 @@ from .common import MessageType, validate_message, logger
 
 
 class ProxyServer:
-    def __init__(self, server_port: int):
+    def __init__(self, server_port: int, heartbeat_interval: int = 60):
         self.server_port = server_port
         self.proxy_servers: Dict[str, asyncio.Server] = {}
         self.proxy_clients: Dict[str, asyncio.StreamWriter] = {}
         self.remote_connections: Dict[str, Dict[str, asyncio.StreamWriter]] = {}
+        self.client_heartbeats = {}
+        self.heartbeat_interval = heartbeat_interval
+        self.heartbeat_timeout = 10
 
     def decode_if_bytes(self, value):
         if isinstance(value, bytes):
@@ -30,7 +33,7 @@ class ProxyServer:
     ):
         client_addr = writer.get_extra_info("peername")
         connection_id = f"{proxy_name}_{client_addr[0]}_{client_addr[1]}"
-        logger.info(f"New remote connection from {client_addr} for proxy {proxy_name}")
+        logger.debug(f"New remote connection from {client_addr} for proxy {proxy_name}")
 
         if proxy_name not in self.remote_connections:
             self.remote_connections[proxy_name] = {}
@@ -65,7 +68,7 @@ class ProxyServer:
                 del self.remote_connections[proxy_name][connection_id]
             writer.close()
             await writer.wait_closed()
-            logger.info(f"Remote connection closed from {client_addr}")
+            logger.debug(f"Remote connection closed from {client_addr}")
 
     async def create_remote_server(self, proxy_name: str, remote_port: int) -> bool:
         try:
@@ -81,101 +84,170 @@ class ProxyServer:
             logger.error(f"Failed to create remote server: {e}")
             return False
 
+    async def cleanup_client(self, proxy_name: str):
+        if proxy_name in self.proxy_clients:
+            del self.proxy_clients[proxy_name]
+
+        if proxy_name in self.proxy_servers:
+            server = self.proxy_servers[proxy_name]
+            server.close()
+            await server.wait_closed()
+            del self.proxy_servers[proxy_name]
+
+        if proxy_name in self.remote_connections:
+            for connection_id, writer in self.remote_connections[proxy_name].items():
+                writer.close()
+                await writer.wait_closed()
+            del self.remote_connections[proxy_name]
+
+        if proxy_name in self.client_heartbeats:
+            del self.client_heartbeats[proxy_name]
+
+        logger.info(f"Cleaned up resources for {proxy_name}")
+
+    async def send_heartbeat(self, writer, proxy_name):
+        message = {
+            "type": MessageType.SERVER_HEARTBEAT.value,
+            "data": {
+                "heartbeat_interval": self.heartbeat_interval,
+            },
+        }
+        writer.write(msgpack.packb(message))
+        await writer.drain()
+        logger.debug(f"Sent heartbeat to client {proxy_name}")
+
+    async def check_client_heartbeats(self):
+        while True:
+            await asyncio.sleep(5)
+            current_time = asyncio.get_event_loop().time()
+            for proxy_name, last_time in list(self.client_heartbeats.items()):
+                if (
+                    current_time - last_time
+                    > self.heartbeat_interval + self.heartbeat_timeout
+                ):
+                    logger.warning(f"Client {proxy_name} heartbeat timeout")
+                    await self.cleanup_client(proxy_name)
+
     async def handle_client(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ):
         client_addr = writer.get_extra_info("peername")
         logger.info(f"New client connection from {client_addr}")
+        unpacker = msgpack.Unpacker()
         try:
             while True:
-                try:
-                    packed_data = await reader.read(8192)
-                    if not packed_data:
-                        break
+                packed_data = await reader.read(8192)
+                if not packed_data:
+                    break
 
-                    message = msgpack.unpackb(packed_data)
-                    logger.debug(f"Received message: {message}")
+                unpacker.feed(packed_data)
+                for message in unpacker:
+                    try:
 
-                    if not validate_message(message):
-                        logger.error("Invalid message format")
-                        continue
+                        if not validate_message(message):
+                            logger.error("Invalid message format")
+                            logger.debug(f"Invalid message: {message}")
+                            continue
 
-                    msg_type = self.decode_if_bytes(
-                        self.get_message_field(message, "type")
-                    )
-                    data = self.get_message_field(message, "data")
-
-                    if msg_type == MessageType.INITIAL_REQUEST.value:
-                        proxy_name = self.decode_if_bytes(
-                            self.get_data_field(data, "proxy_name")
-                        )
-                        remote_port = self.get_data_field(data, "remote_port")
-
-                        success = await self.create_remote_server(
-                            proxy_name, remote_port
+                        msg_type = self.decode_if_bytes(
+                            self.get_message_field(message, "type")
                         )
 
-                        if success:
-                            self.proxy_clients[proxy_name] = writer
+                        if msg_type == MessageType.DATA.value:
+                            logger.verbose(f"Received data message: {message}")
+                        else:
+                            logger.debug(f"Received message: {message}")
+
+                        data = self.get_message_field(message, "data")
+
+                        if msg_type == MessageType.INITIAL_REQUEST.value:
+                            proxy_name = self.decode_if_bytes(
+                                self.get_data_field(data, "proxy_name")
+                            )
+                            remote_port = self.get_data_field(data, "remote_port")
+
+                            success = await self.create_remote_server(
+                                proxy_name, remote_port
+                            )
+
+                            if success:
+                                self.proxy_clients[proxy_name] = writer
+
+                                response = {
+                                    "type": MessageType.INITIAL_RESPONSE.value,
+                                    "data": {
+                                        "proxy_name": proxy_name,
+                                        "remote_port": remote_port,
+                                    },
+                                }
+                                writer.write(msgpack.packb(response))
+                                await writer.drain()
+
+                        elif msg_type == MessageType.DATA.value:
+                            proxy_name = self.decode_if_bytes(
+                                self.get_data_field(data, "proxy_name")
+                            )
+                            binary_data = self.get_data_field(data, "data")
+                            connection_id = self.decode_if_bytes(
+                                self.get_data_field(data, "connection_id")
+                            )
+
+                            if (
+                                proxy_name in self.remote_connections
+                                and connection_id in self.remote_connections[proxy_name]
+                            ):
+                                remote_writer = self.remote_connections[proxy_name][
+                                    connection_id
+                                ]
+                                try:
+                                    remote_writer.write(binary_data)
+                                    await remote_writer.drain()
+                                    logger.debug(
+                                        f"Forwarded data to remote connection {connection_id}"
+                                    )
+                                except Exception as e:
+                                    logger.error(
+                                        f"Failed to forward data to remote connection: {e}"
+                                    )
+                            else:
+                                logger.warning(
+                                    f"No remote connection found for {proxy_name}:{connection_id}"
+                                )
+
+                        elif msg_type == MessageType.CLEANUP_REQUEST.value:
+                            proxy_name = self.decode_if_bytes(
+                                self.get_data_field(data, "proxy_name")
+                            )
+                            await self.cleanup_client(proxy_name)
 
                             response = {
-                                "type": MessageType.INITIAL_RESPONSE.value,
+                                "type": MessageType.CLEANUP_RESPONSE.value,
                                 "data": {
                                     "proxy_name": proxy_name,
-                                    "remote_port": remote_port,
+                                    "status": "success",
                                 },
                             }
                             writer.write(msgpack.packb(response))
                             await writer.drain()
+                            logger.info(f"Sent cleanup response to client {proxy_name}")
 
-                    elif msg_type == MessageType.DATA.value:
-                        proxy_name = self.decode_if_bytes(
-                            self.get_data_field(data, "proxy_name")
-                        )
-                        binary_data = self.get_data_field(data, "data")
-                        connection_id = self.decode_if_bytes(
-                            self.get_data_field(data, "connection_id")
-                        )
-
-                        if (
-                            proxy_name in self.remote_connections
-                            and connection_id in self.remote_connections[proxy_name]
-                        ):
-                            remote_writer = self.remote_connections[proxy_name][
-                                connection_id
-                            ]
-                            try:
-                                remote_writer.write(binary_data)
-                                await remote_writer.drain()
-                                logger.debug(
-                                    f"Forwarded data to remote connection {connection_id}"
-                                )
-                            except Exception as e:
-                                logger.error(
-                                    f"Failed to forward data to remote connection: {e}"
-                                )
-                        else:
-                            logger.warning(
-                                f"No remote connection found for {proxy_name}:{connection_id}"
+                        elif msg_type == MessageType.CLIENT_HEARTBEAT.value:
+                            proxy_name = self.decode_if_bytes(
+                                self.get_data_field(data, "proxy_name")
                             )
+                            self.client_heartbeats[proxy_name] = (
+                                asyncio.get_event_loop().time()
+                            )
+                            await self.send_heartbeat(writer, proxy_name)
+                            continue
 
-                except msgpack.UnpackException as e:
-                    logger.error(f"Failed to unpack message: {e}")
-                except Exception as e:
-                    logger.error(f"Error processing message: {e}")
-                    logger.exception(e)
+                    except Exception as e:
+                        logger.error(f"Error processing message: {e}")
+                        logger.exception(e)
 
         except Exception as e:
             logger.error(f"Client connection error: {e}")
         finally:
-            for proxy_name, w in self.proxy_clients.items():
-                if w == writer:
-                    del self.proxy_clients[proxy_name]
-                    if proxy_name in self.proxy_servers:
-                        self.proxy_servers[proxy_name].close()
-                        await self.proxy_servers[proxy_name].wait_closed()
-                        del self.proxy_servers[proxy_name]
-                    break
             writer.close()
             await writer.wait_closed()
             logger.info(f"Client connection closed from {client_addr}")
@@ -184,6 +256,8 @@ class ProxyServer:
         server = await asyncio.start_server(
             self.handle_client, "0.0.0.0", self.server_port
         )
+
+        _heartbeat_check_task = asyncio.create_task(self.check_client_heartbeats())
 
         async with server:
             logger.info(f"Server started on port {self.server_port}")


### PR DESCRIPTION
1. 由于现在 Client 和 Server 端之间没有活跃状态检查, 所以添加了一个心跳机制。
   - 初次连接时, Server 端主动告诉 Client 自己需要的心跳频率, Client 会根据频率给 Server 发心跳。
   - Server 每 5 秒检查一次超时。超时的 Client 会被清理。
2. Client 如果被清理, 现在 Server 会回收已经被绑定的端口。
3. 添加了一个新的 Log 级别: Verbose。所有类型为 `DATA` 的 MsgPack 都只有 Verbose 下才会被打印。
4. 当请求过多的时候, 多个 MsgPack 有概率粘在一起 (虽然我也不知道为什么...)。如果粘在一起了, Client 和 Server 会无法解析 MsgPack。所以添加了一个 Unpacker 逻辑。(不过这种方案似乎不是长久之计... 最好找出原因。
5. Client 现在断线之后会自动重连了。(但是似乎也导致了一些 `^C` 的 Bug)
6. 给 Logging 加了一个 ColoredFormatter, CLI 现在~~五彩缤纷~~。使用 `--basic-colors` 可以换成基础 ANSI 编码的颜色。
7. 所以为什么会有人往 `README` 里示例命令上加 `-d` 啊喂!